### PR TITLE
feat(retend-utils): add useDocumentVisibility hook.

### DIFF
--- a/packages/retend-utils/source/hooks/index.js
+++ b/packages/retend-utils/source/hooks/index.js
@@ -8,4 +8,5 @@ export * from './use-derived-value.js';
 export * from './use-cursor-position.js';
 export * from './use-intersection-observer.js';
 export * from './use-click-coordinates.js';
+export * from './use-document-visibility.js';
 export { createGlobalStateHook } from './_shared.js';

--- a/packages/retend-utils/source/hooks/use-document-visibility.js
+++ b/packages/retend-utils/source/hooks/use-document-visibility.js
@@ -1,0 +1,40 @@
+import { Cell } from 'retend';
+import { createGlobalStateHook } from './_shared.js';
+
+const USE_DOCUMENT_VISIBILITY_KEY = Symbol(
+  'hooks:useDocumentVisibility:visibilityCache'
+);
+
+/**
+ * Tracks the document's visibility state and provides a reactive cell.
+ *
+ * @returns {Cell<DocumentVisibilityState>} A derived cell containing the document's visibility state.
+ *
+ * @example
+ * import { useDocumentVisibility } from 'retend-utils/hooks';
+ *
+ * const visibility = useDocumentVisibility();
+ * console.log(`Current visibility state: ${visibility.get()}`);
+ */
+export const useDocumentVisibility = createGlobalStateHook({
+  cacheKey: USE_DOCUMENT_VISIBILITY_KEY,
+
+  createSource: () => ({
+    visibilitySource: Cell.source(
+      /** @type {DocumentVisibilityState} */ ('visible')
+    ),
+  }),
+
+  initializeState: (window, cells) => {
+    cells.visibilitySource.set(window.document.visibilityState);
+  },
+
+  setupListeners: (window, cells) => {
+    window.document.addEventListener('visibilitychange', () => {
+      cells.visibilitySource.set(window.document.visibilityState);
+    });
+  },
+
+  createReturnValue: (cells) =>
+    Cell.derived(() => cells.visibilitySource.get()),
+});

--- a/tests/utils/use-document-visibility.spec.tsx
+++ b/tests/utils/use-document-visibility.spec.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { getGlobalContext } from 'retend/context';
+import { browserSetup } from '../setup.ts';
+import { useDocumentVisibility } from '../../packages/retend-utils/source/hooks';
+
+describe('useDocumentVisibility', () => {
+  browserSetup();
+
+  it('should return the initial document visibility state', () => {
+    const visibility = useDocumentVisibility();
+    expect(visibility.get()).toBe('visible');
+  });
+
+  it('should update the visibility state when the visibilitychange event is fired', () => {
+    const { window } = getGlobalContext();
+    const visibility = useDocumentVisibility();
+
+    // Simulate the visibility state changing to hidden
+    Object.defineProperty(window.document, 'visibilityState', {
+      value: 'hidden',
+      writable: true,
+    });
+    window.document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(visibility.get()).toBe('hidden');
+
+    // Simulate the visibility state changing back to visible
+    Object.defineProperty(window.document, 'visibilityState', {
+      value: 'visible',
+      writable: true,
+    });
+    window.document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(visibility.get()).toBe('visible');
+  });
+});


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add `useDocumentVisibility` hook to track document visibility state

- Export new hook from main hooks index

- Include comprehensive test coverage for visibility state changes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["useDocumentVisibility hook"] --> B["Global state management"]
  B --> C["Document visibility tracking"]
  C --> D["Reactive Cell updates"]
  A --> E["Export from hooks index"]
  A --> F["Test coverage"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>use-document-visibility.js</strong><dd><code>Implement useDocumentVisibility hook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/retend-utils/source/hooks/use-document-visibility.js

<ul><li>Create new hook using <code>createGlobalStateHook</code> pattern<br> <li> Track document visibility state with reactive Cell<br> <li> Listen to <code>visibilitychange</code> events for state updates<br> <li> Provide JSDoc documentation with usage example</ul>


</details>


  </td>
  <td><a href="https://github.com/resuite/retend/pull/28/files#diff-b9bf00ff0d1a62a5bcb7cb4480378c43eca7d5d1a6bb1902dc2ca0f68a53bb81">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.js</strong><dd><code>Export useDocumentVisibility hook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/retend-utils/source/hooks/index.js

- Export new `useDocumentVisibility` hook from main hooks index


</details>


  </td>
  <td><a href="https://github.com/resuite/retend/pull/28/files#diff-443c61de1197510ccf48a24abd5f0590b3b9c0ae732addf8b2fbde5ae2ac93a1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>use-document-visibility.spec.tsx</strong><dd><code>Add comprehensive test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/utils/use-document-visibility.spec.tsx

<ul><li>Test initial visibility state returns 'visible'<br> <li> Test visibility state updates on <code>visibilitychange</code> events<br> <li> Mock document visibility state changes for testing</ul>


</details>


  </td>
  <td><a href="https://github.com/resuite/retend/pull/28/files#diff-7da1f75f4bc0a488a755062fe86e2f7ffd230adde9c3b72aa558dbe4e5fe585e">+36/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

