### PR TITLE
Refactor SVG/MathML namespace handling

### DIFF
--- a/packages/retend-web/source/dom-renderer.js
+++ b/packages/retend-web/source/dom-renderer.js
@@ -1,4 +1,4 @@
-/** @import { Observer, ReconcilerOptions, Renderer, __HMR_UpdatableFn, StateSnapshot } from "retend"; */
+/** @import { Observer, ReconcilerOptions, Renderer, __HMR_UpdatableFn, Scope, StateSnapshot } from "retend"; */
 /** @import { JSX } from 'retend/jsx-runtime'; */
 /** @import { ConnectedComment, HiddenElementProperties } from './utils.js'; */
 
@@ -7,6 +7,7 @@ import {
   Cell,
   branchState,
   createNodesFromTemplate,
+  createScope,
   getState,
   normalizeJsxChild,
   withState,
@@ -14,6 +15,7 @@ import {
   setActiveRenderer,
   runPendingSetupEffects,
   linkNodes,
+  useScopeContext,
 } from 'retend';
 
 import * as Ops from './dom-ops.js';
@@ -29,6 +31,11 @@ import {
 const COMMENT_NODE = 8;
 const TEXT_NODE = 3;
 const DOCUMENT_FRAGMENT_NODE = 11;
+/** @type {Scope<string>} */
+const NamespaceScope = createScope('retend-web:Namespace');
+const HTML_NAMESPACE = 'http://www.w3.org/1999/xhtml';
+const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
+const MATH_NAMESPACE = 'http://www.w3.org/1998/Math/MathML';
 
 /**
  * @typedef {Element & HiddenElementProperties} JsxElement
@@ -302,30 +309,6 @@ export class DOMRenderer {
     const shadowRoot = Ops.appendShadowRoot(parentNode, childNode, this);
     if (shadowRoot) return shadowRoot;
 
-    const tagname = parentNode.tagName;
-
-    // Client-side bailout for SVG and MathML elements.
-    //
-    // By default, elements are created using
-    // Document.createElement(), which will only yield HTML-namespaced elements.
-    //
-    // This means that we end up with SVG and MathML specific elements
-    // that look correct, but are not actually SVG or MathML elements.
-    // To fix this, we need to serialize the badly formed elements
-    // and recreate them using the namespace of the nearest svg or math parent.
-    //
-    // This will lead to a loss of interactivity, but idk, you win and you lose.
-    if (
-      (tagname === 'svg' || tagname === 'math') &&
-      childNode instanceof HTMLElement
-    ) {
-      const elementNamespace =
-        parentNode.namespaceURI ?? 'http://www.w3.org/1999/xhtml';
-      const temp = this.host.document.createElementNS(elementNamespace, 'div');
-      temp.innerHTML = /** @type {HTMLElement} */ (childNode).outerHTML;
-      parentNode.append(...temp.children);
-      return parentNode;
-    }
     if (Array.isArray(childNode)) {
       const children = childNode.filter(Boolean);
       parentNode.append(...children);
@@ -371,42 +354,65 @@ export class DOMRenderer {
    * @returns {JsxElement}
    */
   createContainer(tagname, props) {
-    if (this.#isHydrationModeEnabled) {
-      const hydration = this.#getHydrationState();
-      if (hydration) {
-        if (containerIsDynamic(tagname, props, isReactiveChild)) {
-          const branchCursor = hydration.cursor;
-          const activeBranch = getState();
-          const index = `${activeBranch.node.id}.${branchCursor}`;
-          hydration.cursor += 1;
+    let inheritedNamespace = HTML_NAMESPACE;
+    try {
+      inheritedNamespace = useScopeContext(NamespaceScope);
+    } catch {}
 
-          const staticNode = this.#table.get(index);
-          const hydrationNode =
-            staticNode && !this.#hydratedNodes.has(staticNode)
-              ? staticNode
-              : null;
-          if (hydrationNode) {
-            this.#hydratedNodes.add(hydrationNode);
-            const hydrationTask = Promise.resolve().then(() =>
-              this.#hydrateNode(hydrationNode, props)
-            );
-            this.#trackHydrationTask(activeBranch, hydrationTask);
-            return hydrationNode;
-          }
-        }
-        // @ts-expect-error: The types are different in hydration mode.
-        return new Skip(tagname);
-      }
+    const defaultNamespace = props?.xmlns ?? inheritedNamespace;
+    let ns;
+    if (tagname === 'svg') ns = SVG_NAMESPACE;
+    else if (tagname === 'math') ns = MATH_NAMESPACE;
+    else ns = defaultNamespace;
+
+    if (
+      props &&
+      props.xmlns === undefined &&
+      (tagname === 'svg' || tagname === 'math')
+    ) {
+      props.xmlns = ns;
     }
 
-    const defaultNamespace = props?.xmlns ?? 'http://www.w3.org/1999/xhtml';
-    let ns;
-    if (tagname === 'svg') {
-      ns = 'http://www.w3.org/2000/svg';
-    } else if (tagname === 'math') {
-      ns = 'http://www.w3.org/1998/Math/MathML';
-    } else {
-      ns = defaultNamespace;
+    const hydration = this.#isHydrationModeEnabled
+      ? this.#getHydrationState()
+      : null;
+    const isDynamic =
+      hydration && containerIsDynamic(tagname, props, isReactiveChild);
+
+    if (props && tagname !== 'retend-teleport' && 'children' in props) {
+      const childNamespace = tagname === 'foreignObject' ? HTML_NAMESPACE : ns;
+      const children = props.children;
+      props.children = () =>
+        NamespaceScope.Provider({
+          value: childNamespace,
+          children: () => children,
+          h: false,
+        });
+    }
+
+    if (hydration) {
+      if (isDynamic) {
+        const branchCursor = hydration.cursor;
+        const activeBranch = getState();
+        const index = `${activeBranch.node.id}.${branchCursor}`;
+        hydration.cursor += 1;
+
+        const staticNode = this.#table.get(index);
+        const hydrationNode =
+          staticNode && !this.#hydratedNodes.has(staticNode)
+            ? staticNode
+            : null;
+        if (hydrationNode) {
+          this.#hydratedNodes.add(hydrationNode);
+          const hydrationTask = Promise.resolve().then(() =>
+            this.#hydrateNode(hydrationNode, props)
+          );
+          this.#trackHydrationTask(activeBranch, hydrationTask);
+          return hydrationNode;
+        }
+      }
+      // @ts-expect-error: The types are different in hydration mode.
+      return new Skip(tagname);
     }
 
     /** @type {JsxElement} */ // @ts-expect-error

--- a/packages/retend-web/source/dom-renderer.js
+++ b/packages/retend-web/source/dom-renderer.js
@@ -363,6 +363,7 @@ export class DOMRenderer {
     let ns;
     if (tagname === 'svg') ns = SVG_NAMESPACE;
     else if (tagname === 'math') ns = MATH_NAMESPACE;
+    else if (tagname === 'retend-teleport') ns = HTML_NAMESPACE;
     else ns = defaultNamespace;
 
     if (

--- a/tests/attributes.spec.tsx
+++ b/tests/attributes.spec.tsx
@@ -170,6 +170,10 @@ describe('Attributes', () => {
 
       expect(group?.namespaceURI).toBe(SVG_NAMESPACE);
       expect(circle?.namespaceURI).toBe(SVG_NAMESPACE);
+      expect(
+        Reflect.get(element.childNodes[0], '__retendTeleportedContainer')
+          ?.namespaceURI
+      ).toBe(HTML_NAMESPACE);
     });
 
     it('should preserve SVG namespaces for Unique components after moves', async () => {

--- a/tests/attributes.spec.tsx
+++ b/tests/attributes.spec.tsx
@@ -1,7 +1,19 @@
-import { Cell } from 'retend';
+import {
+  Cell,
+  If,
+  Switch,
+  createUnique,
+  getActiveRenderer,
+  runPendingSetupEffects,
+} from 'retend';
+import { Teleport } from 'retend-web';
 import { describe, expect, it } from 'vitest';
 
-import { browserSetup, render, vDomSetup } from './setup.tsx';
+import { browserSetup, render, timeout, vDomSetup } from './setup.tsx';
+
+const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
+const HTML_NAMESPACE = 'http://www.w3.org/1999/xhtml';
+const MATH_NAMESPACE = 'http://www.w3.org/1998/Math/MathML';
 
 const runTests = () => {
   it('should set an attribute on an element', () => {
@@ -22,6 +34,188 @@ describe('Attributes', () => {
   describe('Browser', () => {
     browserSetup();
     runTests();
+
+    it('should preserve SVG namespaces and interactivity through component boundaries', () => {
+      const clicks = Cell.source(0);
+      const IconPart = () => (
+        <g id="group">
+          <circle
+            id="circle"
+            cx="10"
+            cy="10"
+            r="5"
+            onClick={() => clicks.set(clicks.get() + 1)}
+          />
+        </g>
+      );
+      const element = render(
+        <svg id="icon">
+          <IconPart />
+        </svg>
+      );
+      const group = element.querySelector('#group');
+      const circle = element.querySelector('#circle') as SVGCircleElement;
+
+      expect(element.namespaceURI).toBe(SVG_NAMESPACE);
+      expect(group?.namespaceURI).toBe(SVG_NAMESPACE);
+      expect(circle.namespaceURI).toBe(SVG_NAMESPACE);
+
+      circle.dispatchEvent(new MouseEvent('click'));
+      expect(clicks.get()).toBe(1);
+    });
+
+    it('should switch foreignObject descendants back to HTML namespace', () => {
+      const ForeignContent = () => <div id="html-content">HTML</div>;
+      const element = render(
+        <svg id="foreign-root">
+          <foreignObject id="foreign-object">
+            <ForeignContent />
+          </foreignObject>
+        </svg>
+      );
+      const foreignObject = element.querySelector('#foreign-object');
+      const content = element.querySelector('#html-content');
+
+      expect(foreignObject?.namespaceURI).toBe(SVG_NAMESPACE);
+      expect(content?.namespaceURI).toBe(HTML_NAMESPACE);
+      expect(content?.getAttribute('xmlns')).toBeNull();
+    });
+
+    it('should preserve MathML namespaces through component boundaries', () => {
+      const MathPart = () => (
+        <mrow id="math-row">
+          <mi id="math-identifier">x</mi>
+        </mrow>
+      );
+      const element = render(
+        <math id="math-root">
+          <MathPart />
+        </math>
+      );
+      const row = element.querySelector('#math-row');
+      const identifier = element.querySelector('#math-identifier');
+
+      expect(element.namespaceURI).toBe(MATH_NAMESPACE);
+      expect(row?.namespaceURI).toBe(MATH_NAMESPACE);
+      expect(identifier?.namespaceURI).toBe(MATH_NAMESPACE);
+    });
+
+    it('should preserve SVG namespaces through reactive If branches', () => {
+      const show = Cell.source(true);
+      const element = render(
+        <svg id="if-svg">
+          {If(show, () => (
+            <g id="if-group">
+              <circle id="if-circle" />
+            </g>
+          ))}
+        </svg>
+      );
+      let group = element.querySelector('#if-group');
+      let circle = element.querySelector('#if-circle');
+
+      expect(group?.namespaceURI).toBe(SVG_NAMESPACE);
+      expect(circle?.namespaceURI).toBe(SVG_NAMESPACE);
+
+      show.set(false);
+      expect(element.querySelector('#if-group')).toBeNull();
+
+      show.set(true);
+      group = element.querySelector('#if-group');
+      circle = element.querySelector('#if-circle');
+      expect(group?.namespaceURI).toBe(SVG_NAMESPACE);
+      expect(circle?.namespaceURI).toBe(SVG_NAMESPACE);
+    });
+
+    it('should preserve SVG namespaces through Switch cases', () => {
+      const selected = Cell.source('circle');
+      const element = render(
+        <svg id="switch-svg">
+          {Switch(selected, {
+            circle: () => <circle id="switch-circle" />,
+            rect: () => <rect id="switch-rect" />,
+          })}
+        </svg>
+      );
+
+      expect(element.querySelector('#switch-circle')?.namespaceURI).toBe(
+        SVG_NAMESPACE
+      );
+
+      selected.set('rect');
+      expect(element.querySelector('#switch-rect')?.namespaceURI).toBe(
+        SVG_NAMESPACE
+      );
+    });
+
+    it('should preserve namespaces when teleporting SVG content out of an SVG tree', async () => {
+      const target = document.createElement('div');
+      target.id = 'svg-teleport-target';
+      document.body.append(target);
+
+      const element = render(
+        <svg id="teleport-source">
+          <Teleport to="#svg-teleport-target">
+            <g id="teleported-group">
+              <circle id="teleported-circle" />
+            </g>
+          </Teleport>
+        </svg>
+      );
+      document.body.append(element);
+      getActiveRenderer().observer?.flush();
+
+      const group = target.querySelector('#teleported-group');
+      const circle = target.querySelector('#teleported-circle');
+
+      expect(group?.namespaceURI).toBe(SVG_NAMESPACE);
+      expect(circle?.namespaceURI).toBe(SVG_NAMESPACE);
+    });
+
+    it('should preserve SVG namespaces for Unique components after moves', async () => {
+      const slot = Cell.source('first');
+      const UniqueIcon = createUnique(() => (
+        <g id="unique-group">
+          <circle id="unique-circle" />
+        </g>
+      ));
+
+      const element = render(
+        <svg id="unique-svg">
+          {If(
+            Cell.derived(() => slot.get() === 'first'),
+            () => (
+              <UniqueIcon id="icon" />
+            )
+          )}
+          {If(
+            Cell.derived(() => slot.get() === 'second'),
+            () => (
+              <UniqueIcon id="icon" />
+            )
+          )}
+        </svg>
+      );
+      await runPendingSetupEffects();
+
+      expect(element.querySelector('#unique-group')?.namespaceURI).toBe(
+        SVG_NAMESPACE
+      );
+      expect(element.querySelector('#unique-circle')?.namespaceURI).toBe(
+        SVG_NAMESPACE
+      );
+
+      slot.set('second');
+      await runPendingSetupEffects();
+      await timeout();
+
+      expect(element.querySelector('#unique-group')?.namespaceURI).toBe(
+        SVG_NAMESPACE
+      );
+      expect(element.querySelector('#unique-circle')?.namespaceURI).toBe(
+        SVG_NAMESPACE
+      );
+    });
   });
 
   describe('VDom', () => {

--- a/tests/hydration/hydration.spec.tsx
+++ b/tests/hydration/hydration.spec.tsx
@@ -112,6 +112,29 @@ describe('Hydration', () => {
     expect(document.querySelector('#false-branch')).not.toBeNull();
   });
 
+  it('should preserve SVG namespaces through hydrated If blocks', async () => {
+    const show = Cell.source(true);
+    const template = () => (
+      <svg id="hydrated-svg">
+        {If(show, {
+          true: () => <circle id="hydrated-circle" />,
+          false: () => <rect id="hydrated-rect" />,
+        })}
+      </svg>
+    );
+
+    const { document } = await setupHydration(template);
+    expect(document.querySelector('#hydrated-circle')?.namespaceURI).toBe(
+      'http://www.w3.org/2000/svg'
+    );
+
+    show.set(false);
+
+    expect(document.querySelector('#hydrated-rect')?.namespaceURI).toBe(
+      'http://www.w3.org/2000/svg'
+    );
+  });
+
   it('should hydrate For blocks', async () => {
     const items = Cell.source(['Item 1', 'Item 2']);
     const template = () => (


### PR DESCRIPTION
Introduce a scope for managing XML namespaces. This allows for proper handling of SVG and MathML elements within nested structures, including reactive branches and teleported content.

This change also improves the `createContainer` logic by inheriting namespaces from parent scopes and setting them explicitly when needed, rather than relying on string manipulation or re-serialization.